### PR TITLE
Multiple dlls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
         description: 'package from which to find dependents'
         required: true
       dll:
-        description: 'dll from which problematic symbols are imported'
+        description: 'dll(s) from which problematic symbols are imported'
         required: true
       symbols:
         description: 'problematic symbol(s)'
@@ -42,4 +42,8 @@ jobs:
       - name: Grok packages
         run: |
           . pefile/bin/activate
-          python -u package-grokker.py -e '${{ github.event.inputs.repo }}' -p '${{ github.event.inputs.package }}' -d '${{ github.event.inputs.dll }}' ${{ github.event.inputs.symbols }}
+          dlls=""
+          for d in ${{ github.event.inputs.dll }}; do
+            dlls+=" -d $d"
+          done
+          python -u package-grokker.py -e '${{ github.event.inputs.repo }}' -p '${{ github.event.inputs.package }}' $dlls ${{ github.event.inputs.symbols }}

--- a/package-grokker.py
+++ b/package-grokker.py
@@ -9,9 +9,9 @@ import pacdb
 from urllib.request import urlretrieve
 
 class ProblematicImportSearcher(object):
-    def __init__(self, problem_dll, problem_symbols, temp_dir=None, local_mirror=None):
+    def __init__(self, problem_dlls, problem_symbols, temp_dir=None, local_mirror=None):
         super(ProblematicImportSearcher, self).__init__()
-        self.problem_dll = problem_dll.encode('ascii').lower()
+        self.problem_dlls = set(dll.encode('ascii').lower() for dll in problem_dlls)
         self.problem_symbols = set(sym.encode('ascii') for sym in problem_symbols)
         self.temp_dir = temp_dir
         self.local_mirror = local_mirror
@@ -35,7 +35,7 @@ class ProblematicImportSearcher(object):
                     except pefile.PEFormatError:
                         continue
                     for entry in pe.DIRECTORY_ENTRY_IMPORT:
-                        if entry.dll.lower() == self.problem_dll:
+                        if entry.dll.lower() in self.problem_dlls:
                             if not self.problem_symbols:
                                 return pkg
                             for imp in entry.imports:
@@ -46,7 +46,7 @@ class ProblematicImportSearcher(object):
 parser = argparse.ArgumentParser(description='Search packages for problematic imports')
 parser.add_argument('-e', '--repo', default='mingw64', help='pacman repo name to search')
 parser.add_argument('-p', '--package', required=True, help='package from which to find dependents')
-parser.add_argument('-d', '--dll', required=True, help='dll from which problematic symbols are imported')
+parser.add_argument('-d', '--dll', required=True, action='append', help='dll(s) from which problematic symbols are imported')
 parser.add_argument('-l', '--local-mirror', help='root directory of local mirror')
 parser.add_argument('-t', '--tempdir', help='directory for temporary files')
 parser.add_argument('symbol', nargs='*', help='problematic symbol(s)')


### PR DESCRIPTION
Allow multiple dll parameters to script.  Add a loop to action to prepend multiple dll parameters with `-d`